### PR TITLE
feat: auto-update MinIO via Renovate with automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,18 +11,14 @@
   "regexManagers": [
     {
       "fileMatch": ["^minio/Dockerfile$"],
-      "matchStrings": [
-        "ARG MINIO_VERSION=\"(?<currentValue>[^\"]+)\""
-      ],
+      "matchStrings": ["ARG MINIO_VERSION=\"(?<currentValue>[^\"]+)\""],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "minio/minio",
       "versioningTemplate": "loose"
     },
     {
       "fileMatch": ["^minio/build\\.yaml$"],
-      "matchStrings": [
-        "MINIO_VERSION: \"(?<currentValue>[^\"]+)\""
-      ],
+      "matchStrings": ["MINIO_VERSION: \"(?<currentValue>[^\"]+)\""],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "minio/minio",
       "versioningTemplate": "loose"

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,31 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchPackageNames": ["minio/minio"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^minio/Dockerfile$"],
+      "matchStrings": [
+        "ARG MINIO_VERSION=\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "minio/minio",
+      "versioningTemplate": "loose"
+    },
+    {
+      "fileMatch": ["^minio/build\\.yaml$"],
+      "matchStrings": [
+        "MINIO_VERSION: \"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "minio/minio",
+      "versioningTemplate": "loose"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Configures Renovate to track MinIO releases from `github.com/minio/minio` using regex managers
- Covers **both** version pins: `minio/Dockerfile` (default ARG) and `minio/build.yaml` (build-time override)
- Enables automerge (squash) so version bumps land automatically once CI passes

## Details

The MinIO version was hardcoded in two places that were already out of sync (`Dockerfile` at `RELEASE.2024-03-21T23-13-43Z`, `build.yaml` at `RELEASE.2025-02-18T16-25-55Z`). Renovate's first run will open PRs to bring both in sync with the latest release, and future releases will be picked up and merged automatically.

`loose` versioning is used since MinIO's date-based tags (`RELEASE.2024-03-21T23-13-43Z`) sort correctly lexicographically.

## Test plan

- [ ] Trigger a manual Renovate run (or wait for Monday's scheduled run) and verify it opens PRs for `minio/minio` targeting both files
- [ ] Confirm CI passes and the PR automerges