### PR TITLE
ci: allow manual Renovate trigger via workflow_dispatch

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,6 +1,7 @@
 ---
 name: Renovate
 on:
+  workflow_dispatch:
   schedule:
     # The "*" (#42, asterisk) character has special semantics in YAML, so this
     # string has to be quoted.


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to the Renovate workflow so it can be run on demand from the GitHub Actions UI or via `gh workflow run`

Previously the workflow only ran on a weekly cron schedule with no way to trigger it manually.