### PR TITLE
fix: use regex versioning for MinIO date-based releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,14 +14,14 @@
       "matchStrings": ["ARG MINIO_VERSION=\"(?<currentValue>[^\"]+)\""],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "minio/minio",
-      "versioningTemplate": "loose"
+      "versioningTemplate": "regex:^RELEASE\\.(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})T(?<build>.+)Z$"
     },
     {
       "fileMatch": ["^minio/build\\.yaml$"],
       "matchStrings": ["MINIO_VERSION: \"(?<currentValue>[^\"]+)\""],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "minio/minio",
-      "versioningTemplate": "loose"
+      "versioningTemplate": "regex:^RELEASE\\.(?<major>\\d{4})-(?<minor>\\d{2})-(?<patch>\\d{2})T(?<build>.+)Z$"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes Renovate not opening update PRs for the MinIO version.

## Root cause

`loose` versioning in Renovate uses `semver-coerce` under the hood, which returns `null` for strings like `RELEASE.2025-02-18T16-25-55Z` (can't extract semver from them). Renovate silently skips the dependency when it can't parse the current version — confirmed by the Renovate run log showing 2 regex deps found but zero MinIO PRs created.

## Fix

Switch to `regex` versioning with a pattern that maps MinIO's date components to `major`/`minor`/`patch`:

```
^RELEASE\.(?<major>\d{4})-(?<minor>\d{2})-(?<patch>\d{2})T(?<build>.+)Z$
```

`RELEASE.2025-02-18T16-25-55Z` → major=2025, minor=02, patch=18, which Renovate can compare correctly.

## Test plan

- [ ] Merge and trigger a Renovate run — should now open PRs updating MinIO in both `Dockerfile` and `build.yaml`