### PR TITLE
ci: enable debug logging for Renovate

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -18,3 +18,4 @@ jobs:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
+          LOG_LEVEL: debug


### PR DESCRIPTION
Temporary: adds LOG_LEVEL=debug to get full Renovate output and diagnose why MinIO versions are not being updated.