### PR TITLE
fix: prefix published image name with hassio-addon

### DIFF
--- a/seaweedfs/config.yaml
+++ b/seaweedfs/config.yaml
@@ -2,6 +2,7 @@
 name: "SeaweedFS"
 version: "dev"
 slug: "seaweedfs"
+image: "ghcr.io/kalw/hassio-addon-seaweedfs/{arch}"
 description: "SeaweedFS S3-compatible distributed object storage"
 url: "https://github.com/kalw/hassio-addon-seaweedfs"
 arch:


### PR DESCRIPTION
## Summary

- Add `image: "ghcr.io/kalw/hassio-addon-seaweedfs/{arch}"` to `config.yaml`

## Why

Without an explicit `image` field, the deploy workflow derives the GHCR package name from the slug, publishing images as `ghcr.io/kalw/seaweedfs/{arch}`. This is misleading — the package name gives no indication it's a Home Assistant addon or which repo it belongs to. Setting `image` explicitly publishes to `ghcr.io/kalw/hassio-addon-seaweedfs/{arch}`, matching the repository name.

The `slug` (`seaweedfs`) is unchanged so existing HA installations are not affected.

## Test plan

- [ ] After merge, verify the deploy workflow publishes packages as `hassio-addon-seaweedfs` in GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)