### PR TITLE
revert: remove image field from config.yaml

### DIFF
--- a/seaweedfs/config.yaml
+++ b/seaweedfs/config.yaml
@@ -2,7 +2,6 @@
 name: "SeaweedFS"
 version: "dev"
 slug: "seaweedfs"
-image: "ghcr.io/kalw/hassio-addon-seaweedfs/{arch}"
 description: "SeaweedFS S3-compatible distributed object storage"
 url: "https://github.com/kalw/hassio-addon-seaweedfs"
 arch:


### PR DESCRIPTION
## Summary

Reverts the `image` field added in #40.

## Why

The `image` field in `config.yaml` is used by **Home Assistant** to know which GHCR image to pull when installing the addon — it is NOT used by the deploy workflow to determine where to push. The deploy workflow always pushes to `ghcr.io/<owner>/<slug>/<arch>` regardless of this field.

Setting `image: ghcr.io/kalw/hassio-addon-seaweedfs/{arch}` pointed HA at a non-existent image, breaking addon installs. Removing it restores the correct default behaviour (`ghcr.io/kalw/seaweedfs/{arch}`).

> **Note:** renaming the published GHCR package to include `hassio` in the name requires changing the `slug` (a breaking change to the addon ID) or renaming the package directly in GitHub's package settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)