### PR TITLE
fix: rename slug to hassio-addon-seaweedfs

### DIFF
--- a/seaweedfs/config.yaml
+++ b/seaweedfs/config.yaml
@@ -1,7 +1,7 @@
 ---
 name: "SeaweedFS"
 version: "dev"
-slug: "seaweedfs"
+slug: "hassio-addon-seaweedfs"
 description: "SeaweedFS S3-compatible distributed object storage"
 url: "https://github.com/kalw/hassio-addon-seaweedfs"
 arch:


### PR DESCRIPTION
## Summary

- Change `slug` in `config.yaml` from `seaweedfs` to `hassio-addon-seaweedfs`

## Why

The deploy workflow names GHCR images as `ghcr.io/kalw/<slug>/<arch>`. With the old slug `seaweedfs`, published images gave no indication they were a Home Assistant addon. The new slug matches the repository name and makes the package immediately identifiable.

## Breaking change

Existing Home Assistant installations that added this addon will need to be removed and re-added from the repository, as HA tracks addons by slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)