### PR TITLE
fix: bind volume server to 127.0.0.1 to fix data node registration

### DIFF
--- a/seaweedfs/rootfs/etc/services.d/seaweedfs/run
+++ b/seaweedfs/rootfs/etc/services.d/seaweedfs/run
@@ -30,11 +30,15 @@ cat > /etc/seaweedfs/s3.json <<EOF
 EOF
 
 exec weed server \
+    -ip=127.0.0.1 \
     -dir="${data_path}" \
     -filer \
     -s3 \
     -s3.config=/etc/seaweedfs/s3.json \
     -s3.port=8333 \
+    -s3.domainName="" \
     -master.port=9333 \
     -volume.port=8080 \
-    -filer.port=8889
+    -volume.publicUrl="127.0.0.1:8080" \
+    -filer.port=8889 \
+    -filer.s3.region="${s3_region}"


### PR DESCRIPTION
## Summary

- Add `-ip=127.0.0.1` and `-volume.publicUrl=127.0.0.1:8080` to the `weed server` invocation
- Wire up `-filer.s3.region` from the user config (was read but never passed)

## Why

The master was reporting **0 data node candidates** and `Not enough data nodes found!` continuously. In a container, `weed server` auto-detects the host IP for the volume server's advertised address. That address is unreachable from the master (same process, different routing), so the volume server never successfully registers.

Setting `-ip=127.0.0.1` forces all components (master, volume, filer, S3) to bind and advertise on loopback, which is correct for a single-node all-in-one deployment. `-volume.publicUrl` pins the advertised volume server address explicitly.

## Test plan

- [ ] Confirm no more `topo failed to pick 1 from 0 node candidates` errors after addon restart
- [ ] Confirm S3 writes succeed (HA stats collection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)