### PR TITLE
fix: pin image field to correct GHCR path

### DIFF
--- a/seaweedfs/config.yaml
+++ b/seaweedfs/config.yaml
@@ -30,3 +30,4 @@ schema:
   s3_region: "str"
   access_key_id: "str"
   secret_key: "str"
+image: "ghcr.io/kalw/hassio-addon-seaweedfs/{arch}"


### PR DESCRIPTION
## Summary

- Add `image: "ghcr.io/kalw/hassio-addon-seaweedfs/{arch}"` to `config.yaml`

## Why

After the slug rename (#42), the `hassio-addons/workflows` deploy pipeline kept writing `image: ghcr.io/kalw/seaweedfs/{arch}` into `hassio-addons-edge` because it derives the image name from the edge repo's directory name (`seaweedfs/`) rather than from the slug or the image that was actually pushed. HA Supervisor then tried to pull the non-existent old image and got 404.

Pinning the `image` field explicitly ensures the pipeline always copies the correct reference. The edge repo has been manually patched to unblock existing installs immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)