### PR TITLE
fix: remove invalid -filer.s3.region flag

### DIFF
--- a/seaweedfs/rootfs/etc/services.d/seaweedfs/run
+++ b/seaweedfs/rootfs/etc/services.d/seaweedfs/run
@@ -40,5 +40,4 @@ exec weed server \
     -master.port=9333 \
     -volume.port=8080 \
     -volume.publicUrl="127.0.0.1:8080" \
-    -filer.port=8889 \
-    -filer.s3.region="${s3_region}"
+    -filer.port=8889


### PR DESCRIPTION
## Summary

Remove `-filer.s3.region` from the `weed server` invocation.

## Why

SeaweedFS has no such flag — it causes an immediate crash on startup:
```
flag provided but not defined: -filer.s3.region
```

The `s3_region` config option is still read (it is used by S3 clients connecting to the addon, not by the server itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)