### PR TITLE
fix: restore nginx install and bind to 0.0.0.0 for external S3 access

### DIFF
--- a/seaweedfs/Dockerfile
+++ b/seaweedfs/Dockerfile
@@ -1,9 +1,12 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:21.0.0
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.19
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install dependencies
+RUN apk add --no-cache nginx=1.24.0-r16
 
 # Install SeaweedFS
 ARG SEAWEEDFS_VERSION="4.34"

--- a/seaweedfs/rootfs/etc/services.d/seaweedfs/run
+++ b/seaweedfs/rootfs/etc/services.d/seaweedfs/run
@@ -30,7 +30,6 @@ cat > /etc/seaweedfs/s3.json <<EOF
 EOF
 
 exec weed server \
-    -ip=127.0.0.1 \
     -dir="${data_path}" \
     -filer \
     -s3 \


### PR DESCRIPTION
## Summary

- Restores `apk add nginx=1.24.0-r16` and correct `BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.19` that were accidentally dropped when the slug rename PR (#42) was branched off an older commit
- Removes `-ip=127.0.0.1` so all services bind to `0.0.0.0` — without this, the S3 port mapping (`8333/tcp`) cannot forward traffic into the container. Internal volume registration still uses an explicit `-volume.publicUrl=127.0.0.1:8080` so peer communication works

## Test plan

- [x] Built locally with podman and verified `nginx` and `weed` binaries present
- [x] Ran `weed server` with stub credentials; master elected, volume server registered (1 data node)
- [x] Tested S3 endpoint with rclone from host: bucket create, file upload, file list all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)