### PR TITLE
fix: stable volume registration with ip=127.0.0.1 + ip.bind=0.0.0.0 for external S3 access

### DIFF
--- a/seaweedfs/Dockerfile
+++ b/seaweedfs/Dockerfile
@@ -1,9 +1,12 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:21.0.0
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.19
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Install dependencies
+RUN apk add --no-cache nginx=1.24.0-r16
 
 # Install SeaweedFS
 ARG SEAWEEDFS_VERSION="4.34"

--- a/seaweedfs/Dockerfile
+++ b/seaweedfs/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.19
+ARG BUILD_FROM
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 

--- a/seaweedfs/rootfs/etc/services.d/seaweedfs/run
+++ b/seaweedfs/rootfs/etc/services.d/seaweedfs/run
@@ -30,6 +30,8 @@ cat > /etc/seaweedfs/s3.json <<EOF
 EOF
 
 exec weed server \
+    -ip=127.0.0.1 \
+    -ip.bind=0.0.0.0 \
     -dir="${data_path}" \
     -filer \
     -s3 \

--- a/seaweedfs/rootfs/etc/services.d/seaweedfs/run
+++ b/seaweedfs/rootfs/etc/services.d/seaweedfs/run
@@ -30,7 +30,6 @@ cat > /etc/seaweedfs/s3.json <<EOF
 EOF
 
 exec weed server \
-    -ip=127.0.0.1 \
     -dir="${data_path}" \
     -filer \
     -s3 \


### PR DESCRIPTION
## Summary

- Restores `-ip=127.0.0.1` so all internal SeaweedFS components (master, volume, filer) discover each other on stable loopback — the previous fix that removed it caused volume server registration to fail (`0 node candidates`) on the HA supervisor network where auto-detected IPs are unreliable
- Adds `-ip.bind=0.0.0.0` so all services actually listen on all interfaces, making S3 port 8333 reachable through the addon port mapping
- Removes hardcoded `amd64` default from `ARG BUILD_FROM` — the build system always passes the correct arch-specific base image from `build.yaml`

## Test plan

- [x] Built locally with podman
- [x] Volume server registered as `127.0.0.1:8080`, master at `127.0.0.1:9333`, all services listening on `0.0.0.0`
- [x] rclone bucket create + file upload via `localhost:8333` passed from host

🤖 Generated with [Claude Code](https://claude.com/claude-code)