### PR TITLE
fix: raise volume count ceiling to stop uploads failing after 8 volumes

### DIFF
--- a/seaweedfs/rootfs/etc/services.d/seaweedfs/run
+++ b/seaweedfs/rootfs/etc/services.d/seaweedfs/run
@@ -41,4 +41,6 @@ exec weed server \
     -master.port=9333 \
     -volume.port=8080 \
     -volume.publicUrl="127.0.0.1:8080" \
+    -volume.max=0 \
+    -master.volumeSizeLimitMB=1000 \
     -filer.port=8889


### PR DESCRIPTION
## Summary

Root cause of the persistent "Not enough data nodes found" / "0 node candidates" upload failures, confirmed on a production instance via `curl http://127.0.0.1:9333/vol/status`:

```json
"Free":0,"Max":8
```

despite the host having 163GB free (`df -h /share` → 163.7G available). This was unrelated to the IP binding work in #48 — SeaweedFS's `-volume.max` defaults to a **fixed count of 8** regardless of actual free disk space. Once a node accumulates 8 volumes (easy with the default 30GB volume size and normal usage), the master refuses all further volume growth and every subsequent upload fails permanently, even with plenty of disk space.

## Fix

- `-volume.max=0` — volume count auto-scales with actual free disk space instead of being capped at a fixed 8
- `-master.volumeSizeLimitMB=1000` (down from the 30GB default) — smaller individual volumes so more fit in the free-space budget, appropriate for typical HA installs

## Test plan

- [x] Built locally, confirmed via `/vol/status` that `Max` scales with free disk space (`Max: 5513` locally vs the fixed `8` from production) instead of being capped

🤖 Generated with [Claude Code](https://claude.com/claude-code)